### PR TITLE
[codex] Add X-Z 2D frame analysis mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ npm test
 - 断面特性の設定（名称・断面積 A・ねじり定数 Ix・断面二次モーメント Iy, Iz・せん断面積比 ky, kz）
 - 部材端バネ（剛・ピン・回転バネ）の設定と静的縮約
 - 同一変位カップリング（master-slave DOF マッピング）
+- 2Dフレーム解析モード（X-Z平面、uy/rx/rz を自動拘束、全節点 Y=0 を検証）
 - 部材コード角の設定
 - 節点荷重（Fx, Fy, Fz, Mx, My, Mz）
 - 部材荷重（集中荷重・等分布荷重・CMQ荷重）
 
 ### インポート / エクスポート
 - FrameModelMaker-Web 形式（FrameJsonDocument）のインポート
+- FrameModelMaker-Web 形式は3Dモデルとして読み込み（2DモードはProjectFile JSONで保存/復元）
 - JSON形式のエクスポート / インポート
 - サンプルモデル読込
 - IndexedDBオートセーブ

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -131,6 +131,7 @@ export const App: React.FC = () => {
     // Fallback: simple 3D portal frame
     const sampleModel = {
       title: 'Simple 3D Portal Frame',
+      analysisMode: '3d' as const,
       nodes: [
         { id: 'n1', x: 0, y: 0, z: 0, restraint: { ux: true, uy: true, uz: true, rx: true, ry: true, rz: true } },
         { id: 'n2', x: 0, y: 0, z: 400, restraint: { ux: false, uy: false, uz: false, rx: false, ry: false, rz: false } },

--- a/src/core/model/analysisMode.ts
+++ b/src/core/model/analysisMode.ts
@@ -1,8 +1,9 @@
-import type { ProjectModel, Restraint, StructuralNode, AnalysisMode } from './types';
+import type { ProjectModel, Restraint, StructuralNode, AnalysisMode, Member } from './types';
 
 export const DEFAULT_ANALYSIS_MODE: AnalysisMode = '3d';
 export const XZ_2D_MODE: AnalysisMode = 'xz2d';
 export const XZ_PLANE_TOLERANCE = 1e-9;
+export const XZ_2D_CODE_ANGLE_TOLERANCE = 1e-8;
 
 export function getAnalysisMode(model: ProjectModel): AnalysisMode {
   return model.analysisMode ?? DEFAULT_ANALYSIS_MODE;
@@ -19,11 +20,27 @@ export function findNodesOffXzPlane(
   return model.nodes.filter((node) => Math.abs(node.y) > tolerance);
 }
 
+export function isXz2dCodeAngleSupported(
+  codeAngle: number,
+  tolerance = XZ_2D_CODE_ANGLE_TOLERANCE
+): boolean {
+  const normalized = ((codeAngle % 180) + 180) % 180;
+  return normalized <= tolerance || Math.abs(normalized - 180) <= tolerance;
+}
+
+export function findMembersWithUnsupportedXz2dOrientation(
+  model: ProjectModel
+): Member[] {
+  return model.members.filter((member) =>
+    !isXz2dCodeAngleSupported(member.codeAngle)
+  );
+}
+
 export function getEffectiveRestraint(
   restraint: Restraint,
   mode: AnalysisMode
 ): Restraint {
-  if (mode !== XZ_2D_MODE) return restraint;
+  if (mode !== XZ_2D_MODE) return { ...restraint };
   return {
     ...restraint,
     uy: true,

--- a/src/core/model/analysisMode.ts
+++ b/src/core/model/analysisMode.ts
@@ -1,0 +1,33 @@
+import type { ProjectModel, Restraint, StructuralNode, AnalysisMode } from './types';
+
+export const DEFAULT_ANALYSIS_MODE: AnalysisMode = '3d';
+export const XZ_2D_MODE: AnalysisMode = 'xz2d';
+export const XZ_PLANE_TOLERANCE = 1e-9;
+
+export function getAnalysisMode(model: ProjectModel): AnalysisMode {
+  return model.analysisMode ?? DEFAULT_ANALYSIS_MODE;
+}
+
+export function isXz2dMode(model: ProjectModel): boolean {
+  return getAnalysisMode(model) === XZ_2D_MODE;
+}
+
+export function findNodesOffXzPlane(
+  model: ProjectModel,
+  tolerance = XZ_PLANE_TOLERANCE
+): StructuralNode[] {
+  return model.nodes.filter((node) => Math.abs(node.y) > tolerance);
+}
+
+export function getEffectiveRestraint(
+  restraint: Restraint,
+  mode: AnalysisMode
+): Restraint {
+  if (mode !== XZ_2D_MODE) return restraint;
+  return {
+    ...restraint,
+    uy: true,
+    rx: true,
+    rz: true,
+  };
+}

--- a/src/core/model/indexing.ts
+++ b/src/core/model/indexing.ts
@@ -7,6 +7,7 @@ import type {
   NodeId,
   MemberId,
 } from './types';
+import { getAnalysisMode, getEffectiveRestraint } from './analysisMode';
 
 const RIGID: EndRelease = { type: 'rigid', kTheta: 0 };
 const PIN: EndRelease = { type: 'pin', kTheta: 0 };
@@ -84,6 +85,7 @@ function resolveSpring(
 export function buildIndexedModel(model: ProjectModel): IndexedModel {
   const nodeIdToIndex = new Map<NodeId, number>();
   const memberIdToIndex = new Map<MemberId, number>();
+  const analysisMode = getAnalysisMode(model);
 
   // Build spring lookup
   const springMap = new Map(
@@ -98,7 +100,7 @@ export function buildIndexedModel(model: ProjectModel): IndexedModel {
       x: n.x,
       y: n.y,
       z: n.z,
-      restraint: { ...n.restraint },
+      restraint: getEffectiveRestraint(n.restraint, analysisMode),
     };
   });
 

--- a/src/core/model/types.ts
+++ b/src/core/model/types.ts
@@ -4,6 +4,7 @@ export type MemberId = string;
 export type MaterialId = string;
 export type SectionId = string;
 export type SpringId = string;
+export type AnalysisMode = '3d' | 'xz2d';
 
 // ── Model entities ──
 export interface Restraint {
@@ -131,6 +132,7 @@ export interface CouplingConstraint {
 // ── Project model ──
 export interface ProjectModel {
   title: string;
+  analysisMode?: AnalysisMode;
   nodes: StructuralNode[];
   materials: Material[];
   sections: Section[];

--- a/src/core/model/validation.ts
+++ b/src/core/model/validation.ts
@@ -1,7 +1,25 @@
 import type { ProjectModel, AnalysisError } from './types';
+import {
+  findNodesOffXzPlane,
+  getAnalysisMode,
+  getEffectiveRestraint,
+  XZ_2D_MODE,
+} from './analysisMode';
 
 export function validateModel(model: ProjectModel): AnalysisError[] {
   const errors: AnalysisError[] = [];
+  const analysisMode = getAnalysisMode(model);
+
+  if (analysisMode === XZ_2D_MODE) {
+    const offPlaneNodes = findNodesOffXzPlane(model);
+    if (offPlaneNodes.length > 0) {
+      errors.push({
+        type: 'validation',
+        message: `2D X-Z平面モードでは全節点のY座標が0である必要があります。対象節点: ${offPlaneNodes.map((n) => n.id).join(', ')}`,
+        nodeId: offPlaneNodes[0]!.id,
+      });
+    }
+  }
 
   // Check: at least one node
   if (model.nodes.length === 0) {
@@ -128,9 +146,12 @@ export function validateModel(model: ProjectModel): AnalysisError[] {
   }
 
   // Check: constraint sufficiency (3 translational directions)
-  const hasUx = model.nodes.some((n) => n.restraint.ux);
-  const hasUy = model.nodes.some((n) => n.restraint.uy);
-  const hasUz = model.nodes.some((n) => n.restraint.uz);
+  const effectiveRestraints = model.nodes.map((n) =>
+    getEffectiveRestraint(n.restraint, analysisMode)
+  );
+  const hasUx = effectiveRestraints.some((r) => r.ux);
+  const hasUy = effectiveRestraints.some((r) => r.uy);
+  const hasUz = effectiveRestraints.some((r) => r.uz);
   if (!hasUx || !hasUy || !hasUz) {
     errors.push({
       type: 'validation',

--- a/src/core/model/validation.ts
+++ b/src/core/model/validation.ts
@@ -1,22 +1,39 @@
 import type { ProjectModel, AnalysisError } from './types';
 import {
   findNodesOffXzPlane,
+  findMembersWithUnsupportedXz2dOrientation,
   getAnalysisMode,
   getEffectiveRestraint,
   XZ_2D_MODE,
 } from './analysisMode';
 
+const LOAD_TOLERANCE = 1e-9;
+
+function isNonzero(value: number): boolean {
+  return Math.abs(value) > LOAD_TOLERANCE;
+}
+
 export function validateModel(model: ProjectModel): AnalysisError[] {
   const errors: AnalysisError[] = [];
   const analysisMode = getAnalysisMode(model);
+  const isXz2d = analysisMode === XZ_2D_MODE;
 
-  if (analysisMode === XZ_2D_MODE) {
+  if (isXz2d) {
     const offPlaneNodes = findNodesOffXzPlane(model);
     if (offPlaneNodes.length > 0) {
       errors.push({
         type: 'validation',
         message: `2D X-Z平面モードでは全節点のY座標が0である必要があります。対象節点: ${offPlaneNodes.map((n) => n.id).join(', ')}`,
         nodeId: offPlaneNodes[0]!.id,
+      });
+    }
+
+    const unsupportedMembers = findMembersWithUnsupportedXz2dOrientation(model);
+    if (unsupportedMembers.length > 0) {
+      errors.push({
+        type: 'validation',
+        message: `2D X-Z平面モードでは部材コード角を0度または180度系にしてください。対象部材: ${unsupportedMembers.map((m) => m.id).join(', ')}`,
+        elementId: unsupportedMembers[0]!.id,
       });
     }
   }
@@ -186,6 +203,33 @@ export function validateModel(model: ProjectModel): AnalysisError[] {
         elementId: ml.id,
       });
     }
+    if (isXz2d) {
+      if ((ml.type === 'point' || ml.type === 'udl') &&
+          ml.direction === 'localY' &&
+          isNonzero(ml.value)) {
+        errors.push({
+          type: 'validation',
+          message: `2D X-Z平面モードでは部材荷重 ${ml.id} の localY 方向荷重は使用できません。localX または localZ を使用してください。`,
+          elementId: ml.id,
+        });
+      }
+      if (ml.type === 'cmq') {
+        const invalid = [
+          ['iQy', ml.iQy],
+          ['jQy', ml.jQy],
+          ['iMz', ml.iMz],
+          ['jMz', ml.jMz],
+          ['moz', ml.moz],
+        ].filter(([, value]) => isNonzero(value as number));
+        if (invalid.length > 0) {
+          errors.push({
+            type: 'validation',
+            message: `2D X-Z平面モードではCMQ荷重 ${ml.id} の面外成分 (${invalid.map(([name]) => name).join(', ')}) は使用できません。`,
+            elementId: ml.id,
+          });
+        }
+      }
+    }
   }
 
   // Check: nodal loads
@@ -196,6 +240,20 @@ export function validateModel(model: ProjectModel): AnalysisError[] {
         message: `節点荷重 ${nl.id} の対象節点 ${nl.nodeId} が見つかりません。`,
         nodeId: nl.nodeId,
       });
+    }
+    if (isXz2d) {
+      const invalid = [
+        ['fy', nl.fy],
+        ['mx', nl.mx],
+        ['mz', nl.mz],
+      ].filter(([, value]) => isNonzero(value as number));
+      if (invalid.length > 0) {
+        errors.push({
+          type: 'validation',
+          message: `2D X-Z平面モードでは節点荷重 ${nl.id} の面外成分 (${invalid.map(([name]) => name).join(', ')}) は使用できません。fx, fz, my を使用してください。`,
+          nodeId: nl.nodeId,
+        });
+      }
     }
   }
 

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -66,6 +66,10 @@ const ja = {
   'prop.loadIntensity': '強度:',
   'prop.loadMagnitude': '大きさ:',
   'prop.loadPosition': '位置 a:',
+  'prop.analysisMode': '解析モード',
+  'prop.analysisMode3d': '3Dフレーム',
+  'prop.analysisModeXz2d': '2Dフレーム（X-Z）',
+  'prop.yLockedXz2d': '2D X-ZモードではY座標は0固定です',
 
   // Property panel - display settings
   'prop.displaySettings': '表示設定',
@@ -225,6 +229,10 @@ const en: Record<keyof typeof ja, string> = {
   'prop.loadIntensity': 'Intensity:',
   'prop.loadMagnitude': 'Magnitude:',
   'prop.loadPosition': 'Pos. a:',
+  'prop.analysisMode': 'Analysis Mode',
+  'prop.analysisMode3d': '3D Frame',
+  'prop.analysisModeXz2d': '2D Frame (X-Z)',
+  'prop.yLockedXz2d': 'Y is fixed at 0 in 2D X-Z mode',
 
   'prop.displaySettings': 'Display Settings',
   'prop.nodeLabels': 'Node Labels',

--- a/src/io/frameJsonConverter.ts
+++ b/src/io/frameJsonConverter.ts
@@ -202,6 +202,8 @@ export function convertFrameJson(
 
   return {
     title: doc.title || 'Imported Model',
+    // FrameJson is imported as a full 3D frame. Native ProjectFile JSON
+    // preserves analysisMode when users need xz2d round-tripping.
     analysisMode: '3d',
     nodes,
     materials,

--- a/src/io/frameJsonConverter.ts
+++ b/src/io/frameJsonConverter.ts
@@ -202,6 +202,7 @@ export function convertFrameJson(
 
   return {
     title: doc.title || 'Imported Model',
+    analysisMode: '3d',
     nodes,
     materials,
     sections,

--- a/src/state/projectStore.ts
+++ b/src/state/projectStore.ts
@@ -11,10 +11,18 @@ import type {
   DiagramPoint,
   AnalysisError,
   Restraint,
+  AnalysisMode,
 } from '../core/model/types';
 import type { WorkerResponse } from '../worker/protocol';
 import { parseFrameJsonText, isFrameJsonFormat } from '../io/frameJsonParser';
 import { convertFrameJson } from '../io/frameJsonConverter';
+import {
+  DEFAULT_ANALYSIS_MODE,
+  XZ_2D_MODE,
+  findNodesOffXzPlane,
+  getAnalysisMode,
+  isXz2dMode,
+} from '../core/model/analysisMode';
 
 /** Distributive Omit that works correctly with union types */
 type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
@@ -28,10 +36,30 @@ const DEFAULT_RESTRAINT: Restraint = {
   rx: false, ry: false, rz: false,
 };
 
+export type AnalysisModeUpdateResult =
+  | { ok: true }
+  | { ok: false; error: string; nodeIds: string[] };
+
+function normalizeProjectModel(model: ProjectModel): ProjectModel {
+  return {
+    ...model,
+    analysisMode: model.analysisMode ?? DEFAULT_ANALYSIS_MODE,
+    springs: model.springs ?? [],
+    couplings: model.couplings ?? [],
+    nodalLoads: model.nodalLoads ?? [],
+    memberLoads: model.memberLoads ?? [],
+  };
+}
+
+function formatOffPlaneError(nodeIds: string[]): string {
+  return `2D X-Z平面モードに切り替えるには、すべての節点のY座標を0にしてください。対象節点: ${nodeIds.join(', ')}`;
+}
+
 function createDefaultModel(): ProjectModel {
   const matId = generateId();
   return {
     title: '',
+    analysisMode: DEFAULT_ANALYSIS_MODE,
     nodes: [],
     materials: [
       { id: matId, name: 'Steel', E: 20500, G: 7900, nu: 0.3, expansion: 0.000012 },
@@ -102,6 +130,7 @@ interface ProjectState {
   setAnalyzing: (v: boolean) => void;
   setAnalysisResult: (resp: WorkerResponse) => void;
   markResultStale: () => void;
+  setAnalysisMode: (mode: AnalysisMode) => AnalysisModeUpdateResult;
 
   // Project
   loadModel: (model: ProjectModel) => void;
@@ -123,10 +152,14 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
   addNode: (x, y, z) => {
     const id = generateId();
+    const currentModel = get().model;
     set((s) => ({
       model: {
         ...s.model,
-        nodes: [...s.model.nodes, { id, x, y, z, restraint: { ...DEFAULT_RESTRAINT } }],
+        nodes: [
+          ...s.model.nodes,
+          { id, x, y: isXz2dMode(currentModel) ? 0 : y, z, restraint: { ...DEFAULT_RESTRAINT } },
+        ],
       },
       isResultStale: true,
     }));
@@ -138,7 +171,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       model: {
         ...s.model,
         nodes: s.model.nodes.map((n) =>
-          n.id === id ? { ...n, ...updates } : n
+          n.id === id
+            ? { ...n, ...updates, ...(isXz2dMode(s.model) ? { y: 0 } : {}) }
+            : n
         ),
       },
       isResultStale: true,
@@ -400,8 +435,26 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
   markResultStale: () => set({ isResultStale: true }),
 
+  setAnalysisMode: (mode) => {
+    if (mode === XZ_2D_MODE) {
+      const offPlaneNodes = findNodesOffXzPlane(get().model);
+      if (offPlaneNodes.length > 0) {
+        const nodeIds = offPlaneNodes.map((node) => node.id);
+        return { ok: false, error: formatOffPlaneError(nodeIds), nodeIds };
+      }
+    }
+
+    if (getAnalysisMode(get().model) === mode) return { ok: true };
+
+    set((s) => ({
+      model: { ...s.model, analysisMode: mode },
+      isResultStale: true,
+    }));
+    return { ok: true };
+  },
+
   loadModel: (model) => set((s) => ({
-    model,
+    model: normalizeProjectModel(model),
     analysisResult: null,
     analysisError: null,
     isResultStale: false,
@@ -412,7 +465,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     const doc = parseFrameJsonText(text);
     const model = convertFrameJson(doc, loadCaseIndex);
     set((s) => ({
-      model,
+      model: normalizeProjectModel(model),
       analysisResult: null,
       analysisError: null,
       isResultStale: false,
@@ -432,7 +485,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       const doc = parseFrameJsonText(text);
       const model = convertFrameJson(doc);
       set((s) => ({
-        model,
+        model: normalizeProjectModel(model),
         analysisResult: null,
         analysisError: null,
         isResultStale: false,
@@ -442,7 +495,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       const pf = parsed as { model?: ProjectModel };
       if (pf.model) {
         set((s) => ({
-          model: pf.model!,
+          model: normalizeProjectModel(pf.model!),
           analysisResult: null,
           analysisError: null,
           isResultStale: false,

--- a/src/state/projectStore.ts
+++ b/src/state/projectStore.ts
@@ -41,6 +41,7 @@ export type AnalysisModeUpdateResult =
   | { ok: false; error: string; nodeIds: string[] };
 
 function normalizeProjectModel(model: ProjectModel): ProjectModel {
+  // Idempotently fills defaults for older persisted/imported project files.
   return {
     ...model,
     analysisMode: model.analysisMode ?? DEFAULT_ANALYSIS_MODE,
@@ -152,13 +153,12 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
   addNode: (x, y, z) => {
     const id = generateId();
-    const currentModel = get().model;
     set((s) => ({
       model: {
         ...s.model,
         nodes: [
           ...s.model.nodes,
-          { id, x, y: isXz2dMode(currentModel) ? 0 : y, z, restraint: { ...DEFAULT_RESTRAINT } },
+          { id, x, y: isXz2dMode(s.model) ? 0 : y, z, restraint: { ...DEFAULT_RESTRAINT } },
         ],
       },
       isResultStale: true,

--- a/src/tests/unit/analysis.test.ts
+++ b/src/tests/unit/analysis.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildIndexedModel } from '../../core/model/indexing';
+import { validateModel } from '../../core/model/validation';
 import { analyzeFrame } from '../../core/analysis/analyzeFrame';
 import type { ProjectModel, Restraint } from '../../core/model/types';
 
@@ -145,6 +146,66 @@ describe('3D Axial member', () => {
     const delta = (F * L) / (E * A);
     // Node 1 ux at DOF 6*1 + 0 = 6
     expect(result.displacements[6]).toBeCloseTo(delta, 8);
+  });
+});
+
+describe('2D X-Z frame analysis mode', () => {
+  const P = -10;
+  const L = 4;
+  const E = 200e6;
+  const Iy = 8.333e-6;
+  const nu = 0.3;
+  const G = E / (2 * (1 + nu));
+  const A = 0.01;
+
+  function buildModel(): ProjectModel {
+    const model = createBaseModel();
+    model.analysisMode = 'xz2d';
+    model.nodes = [
+      {
+        id: 'n0',
+        x: 0,
+        y: 0,
+        z: 0,
+        restraint: { ...FREE, ux: true, uz: true, ry: true },
+      },
+      { id: 'n1', x: L, y: 0, z: 0, restraint: FREE },
+    ];
+    model.members = [defaultMember('m1', 'n0', 'n1')];
+    model.nodalLoads = [
+      { id: 'nl1', nodeId: 'n1', fx: 0, fy: 0, fz: P, mx: 0, my: 0, mz: 0 },
+    ];
+    return model;
+  }
+
+  it('auto-restrains out-of-plane DOFs while leaving X-Z frame DOFs active', () => {
+    const model = buildModel();
+    expect(validateModel(model)).toHaveLength(0);
+
+    const indexed = buildIndexedModel(model);
+    expect(indexed.nodes[1]!.restraint.uy).toBe(true);
+    expect(indexed.nodes[1]!.restraint.rx).toBe(true);
+    expect(indexed.nodes[1]!.restraint.rz).toBe(true);
+    expect(indexed.nodes[1]!.restraint.uz).toBe(false);
+    expect(indexed.nodes[1]!.restraint.ry).toBe(false);
+
+    const result = analyzeFrame({ model: indexed });
+    const ky = 0.5;
+    const Asy = ky * A;
+    const delta = (P * L * L * L) / (3 * E * Iy) + (P * L) / (G * Asy);
+
+    expect(result.displacements[7]).toBeCloseTo(0, 8);  // uy
+    expect(result.displacements[9]).toBeCloseTo(0, 8);  // rx
+    expect(result.displacements[11]).toBeCloseTo(0, 8); // rz
+    expect(result.displacements[8]).toBeCloseTo(delta, 4); // uz remains active
+  });
+
+  it('rejects X-Z 2D analysis when any node has nonzero Y', () => {
+    const model = buildModel();
+    model.nodes[1] = { ...model.nodes[1]!, y: 0.25 };
+
+    const errors = validateModel(model);
+    expect(errors.some((error) => error.message.includes('Y座標が0'))).toBe(true);
   });
 });
 

--- a/src/tests/unit/analysis.test.ts
+++ b/src/tests/unit/analysis.test.ts
@@ -207,6 +207,42 @@ describe('2D X-Z frame analysis mode', () => {
     const errors = validateModel(model);
     expect(errors.some((error) => error.message.includes('Y座標が0'))).toBe(true);
   });
+
+  it('rejects unsupported member code angles in X-Z 2D mode', () => {
+    const model = buildModel();
+    model.members[0] = { ...model.members[0]!, codeAngle: 90 };
+
+    const errors = validateModel(model);
+    expect(errors.some((error) => error.message.includes('コード角'))).toBe(true);
+  });
+
+  it('rejects out-of-plane nodal load components in X-Z 2D mode', () => {
+    const model = buildModel();
+    model.nodalLoads[0] = { ...model.nodalLoads[0]!, fy: 1, mx: 2, mz: 3 };
+
+    const errors = validateModel(model);
+    expect(errors.some((error) => error.message.includes('面外成分'))).toBe(true);
+  });
+
+  it('rejects out-of-plane member load components in X-Z 2D mode', () => {
+    const model = buildModel();
+    model.nodalLoads = [];
+    model.memberLoads = [
+      { id: 'ml1', memberId: 'm1', type: 'udl', direction: 'localY', value: -1 },
+      {
+        id: 'cmq1',
+        memberId: 'm1',
+        type: 'cmq',
+        iQx: 0, iQy: 1, iQz: 0, iMy: 0, iMz: 2,
+        jQx: 0, jQy: 0, jQz: 0, jMy: 0, jMz: 0,
+        moy: 0, moz: 3,
+      },
+    ];
+
+    const errors = validateModel(model);
+    expect(errors.some((error) => error.message.includes('localY'))).toBe(true);
+    expect(errors.some((error) => error.message.includes('CMQ'))).toBe(true);
+  });
 });
 
 describe('3D Torsion member', () => {

--- a/src/tests/unit/projectStore.test.ts
+++ b/src/tests/unit/projectStore.test.ts
@@ -64,6 +64,23 @@ describe('projectStore basic operations', () => {
     expect(added!.y).toBe(0);
   });
 
+  it('preserves user restraint values when toggling back from 2D X-Z to 3D', () => {
+    const state = useProjectStore.getState();
+    const id = state.addNode(0, 0, 0);
+
+    let result = useProjectStore.getState().setAnalysisMode('xz2d');
+    expect(result.ok).toBe(true);
+    expect(useProjectStore.getState().model.nodes.find(n => n.id === id)!.restraint.uy).toBe(false);
+    expect(useProjectStore.getState().model.nodes.find(n => n.id === id)!.restraint.rx).toBe(false);
+    expect(useProjectStore.getState().model.nodes.find(n => n.id === id)!.restraint.rz).toBe(false);
+
+    result = useProjectStore.getState().setAnalysisMode('3d');
+    expect(result.ok).toBe(true);
+    expect(useProjectStore.getState().model.nodes.find(n => n.id === id)!.restraint.uy).toBe(false);
+    expect(useProjectStore.getState().model.nodes.find(n => n.id === id)!.restraint.rx).toBe(false);
+    expect(useProjectStore.getState().model.nodes.find(n => n.id === id)!.restraint.rz).toBe(false);
+  });
+
   it('imports FrameJson format', () => {
     const frameJson = JSON.stringify({
       title: "Test",

--- a/src/tests/unit/projectStore.test.ts
+++ b/src/tests/unit/projectStore.test.ts
@@ -8,6 +8,7 @@ describe('projectStore basic operations', () => {
 
   it('creates default model with 3D properties', () => {
     const model = useProjectStore.getState().model;
+    expect(model.analysisMode).toBe('3d');
     expect(model.materials.length).toBeGreaterThan(0);
     expect(model.sections.length).toBeGreaterThan(0);
     expect(model.materials[0]!.G).toBeGreaterThan(0);
@@ -37,6 +38,30 @@ describe('projectStore basic operations', () => {
     expect(member).toBeDefined();
     expect(member!.codeAngle).toBe(0);
     expect(member!.iSprings).toEqual({ x: 0, y: 0, z: 0 });
+  });
+
+  it('rejects 2D X-Z mode when nodes are off the X-Z plane', () => {
+    const state = useProjectStore.getState();
+    state.addNode(0, 1, 0);
+
+    const result = useProjectStore.getState().setAnalysisMode('xz2d');
+    expect(result.ok).toBe(false);
+    expect(useProjectStore.getState().model.analysisMode).toBe('3d');
+  });
+
+  it('keeps node Y at zero while 2D X-Z mode is active', () => {
+    const state = useProjectStore.getState();
+    const id = state.addNode(0, 0, 0);
+
+    const result = useProjectStore.getState().setAnalysisMode('xz2d');
+    expect(result.ok).toBe(true);
+
+    useProjectStore.getState().updateNode(id, { y: 3 });
+    expect(useProjectStore.getState().model.nodes[0]!.y).toBe(0);
+
+    const id2 = useProjectStore.getState().addNode(1, 5, 2);
+    const added = useProjectStore.getState().model.nodes.find(n => n.id === id2);
+    expect(added!.y).toBe(0);
   });
 
   it('imports FrameJson format', () => {

--- a/src/tests/unit/resultsPanel.test.ts
+++ b/src/tests/unit/resultsPanel.test.ts
@@ -50,4 +50,37 @@ describe('buildEffectiveReactionRows', () => {
       isRepresentative: false,
     });
   });
+
+  it('shows auto-fixed out-of-plane reactions in X-Z 2D mode', () => {
+    const model = createBaseModel();
+    model.analysisMode = 'xz2d';
+    model.nodes = [
+      { id: 'free2d', x: 0, y: 0, z: 0, restraint: FREE },
+    ];
+
+    const reactions = new Array(model.nodes.length * 6).fill(0);
+    reactions[1] = 1.1; // uy
+    reactions[3] = 3.3; // rx
+    reactions[5] = 5.5; // rz
+
+    const { rows, hasSharedReactions } = buildEffectiveReactionRows(model, reactions);
+
+    expect(hasSharedReactions).toBe(false);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.cells[1]).toEqual({
+      value: 1.1,
+      isShared: false,
+      isRepresentative: true,
+    });
+    expect(rows[0]!.cells[3]).toEqual({
+      value: 3.3,
+      isShared: false,
+      isRepresentative: true,
+    });
+    expect(rows[0]!.cells[5]).toEqual({
+      value: 5.5,
+      isShared: false,
+      isRepresentative: true,
+    });
+  });
 });

--- a/src/ui/panels/CanvasPanel.tsx
+++ b/src/ui/panels/CanvasPanel.tsx
@@ -4,6 +4,7 @@ import type { EditAction } from '../../rendering/threeApp';
 import { useProjectStore } from '../../state/projectStore';
 import { useViewStore } from '../../state/viewStore';
 import { useSelectionStore } from '../../state/selectionStore';
+import { isXz2dMode } from '../../core/model/analysisMode';
 
 const FIXED_RESTRAINT = { ux: true, uy: true, uz: true, rx: true, ry: true, rz: true };
 const FREE_RESTRAINT = { ux: false, uy: false, uz: false, rx: false, ry: false, rz: false };
@@ -63,10 +64,13 @@ export const CanvasPanel: React.FC = () => {
         addNodalLoad({ nodeId: action.nodeId, fx: 0, fy: 0, fz: -10, mx: 0, my: 0, mz: 0 });
         selectNode(action.nodeId);
         break;
-      case 'addMemberLoad':
-        addMemberLoad({ memberId: action.memberId, type: 'udl', direction: 'localY', value: -5 });
+      case 'addMemberLoad': {
+        const currentModel = useProjectStore.getState().model;
+        const direction = isXz2dMode(currentModel) ? 'localZ' : 'localY';
+        addMemberLoad({ memberId: action.memberId, type: 'udl', direction, value: -5 });
         selectMember(action.memberId);
         break;
+      }
       case 'moveNode':
         updateNode(action.nodeId, { x: action.x, y: action.y, z: action.z });
         break;

--- a/src/ui/panels/PropertyPanel.tsx
+++ b/src/ui/panels/PropertyPanel.tsx
@@ -3,7 +3,8 @@ import { useProjectStore } from '../../state/projectStore';
 import { useSelectionStore } from '../../state/selectionStore';
 import { useViewStore } from '../../state/viewStore';
 import { useT } from '../../i18n';
-import type { StructuralNode, Member, NodalLoad, MemberLoad } from '../../core/model/types';
+import type { StructuralNode, Member, NodalLoad, MemberLoad, AnalysisMode } from '../../core/model/types';
+import { getAnalysisMode, XZ_2D_MODE } from '../../core/model/analysisMode';
 
 /** Distributive Omit that works correctly with union types */
 type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
@@ -41,6 +42,7 @@ export const PropertyPanel: React.FC = () => {
 
   const selectedNodes = model.nodes.filter((n) => selectedNodeIds.has(n.id));
   const selectedMembers = model.members.filter((m) => selectedMemberIds.has(m.id));
+  const analysisMode = getAnalysisMode(model);
 
   return (
     <div className="property-panel">
@@ -49,6 +51,7 @@ export const PropertyPanel: React.FC = () => {
       {selectedNodes.length === 1 && (
         <NodeProperties
           node={selectedNodes[0]!}
+          analysisMode={analysisMode}
           nodalLoads={model.nodalLoads.filter((l) => l.nodeId === selectedNodes[0]!.id)}
           onUpdate={updateNode}
           onDelete={removeNode}
@@ -75,6 +78,7 @@ export const PropertyPanel: React.FC = () => {
 
       {selectedNodes.length === 0 && selectedMembers.length === 0 && (
         <>
+          <AnalysisModeEditor />
           <MaterialsEditor />
           <SectionsEditor />
           <CouplingsEditor />
@@ -115,13 +119,14 @@ export const PropertyPanel: React.FC = () => {
 
 const NodeProperties: React.FC<{
   node: StructuralNode;
+  analysisMode: AnalysisMode;
   nodalLoads: NodalLoad[];
   onUpdate: (id: string, u: Partial<Pick<StructuralNode, 'x' | 'y' | 'z' | 'restraint'>>) => void;
   onDelete: (id: string) => void;
   onAddLoad: (nodeId: string) => void;
   onUpdateLoad: (id: string, updates: Partial<Omit<NodalLoad, 'id'>>) => void;
   onRemoveLoad: (id: string) => void;
-}> = ({ node, nodalLoads, onUpdate, onDelete, onAddLoad, onUpdateLoad, onRemoveLoad }) => {
+}> = ({ node, analysisMode, nodalLoads, onUpdate, onDelete, onAddLoad, onUpdateLoad, onRemoveLoad }) => {
   const t = useT();
   const restraintKeys = ['ux', 'uy', 'uz', 'rx', 'ry', 'rz'] as const;
   const restraintLabels = {
@@ -132,13 +137,18 @@ const NodeProperties: React.FC<{
   return (
     <div className="prop-group">
       <div className="prop-title">{t('prop.node')} {node.id.substring(0, 5)}</div>
-      {(['x', 'y', 'z'] as const).map((axis) => (
-        <div className="prop-row" key={axis}>
-          <label>{axis.toUpperCase()}:</label>
-          <input type="number" value={node[axis]} step="1"
-            onChange={(e) => onUpdate(node.id, { [axis]: Number(e.target.value) })} />
-        </div>
-      ))}
+      {(['x', 'y', 'z'] as const).map((axis) => {
+        const yLocked = analysisMode === XZ_2D_MODE && axis === 'y';
+        return (
+          <div className="prop-row" key={axis}>
+            <label>{axis.toUpperCase()}:</label>
+            <input type="number" value={node[axis]} step="1"
+              disabled={yLocked}
+              title={yLocked ? t('prop.yLockedXz2d') : undefined}
+              onChange={(e) => onUpdate(node.id, { [axis]: Number(e.target.value) })} />
+          </div>
+        );
+      })}
       <div className="prop-title">{t('prop.restraints')}</div>
       {restraintKeys.map((key) => (
         <label className="checkbox-label" key={key}>
@@ -165,6 +175,34 @@ const NodeProperties: React.FC<{
         <button onClick={() => onAddLoad(node.id)}>{t('prop.addLoad')}</button>
         <button className="danger" onClick={() => onDelete(node.id)}>{t('prop.delete')}</button>
       </div>
+    </div>
+  );
+};
+
+const AnalysisModeEditor: React.FC = () => {
+  const model = useProjectStore((s) => s.model);
+  const setAnalysisMode = useProjectStore((s) => s.setAnalysisMode);
+  const [error, setError] = React.useState<string | null>(null);
+  const t = useT();
+  const mode = getAnalysisMode(model);
+
+  return (
+    <div className="prop-group">
+      <div className="prop-title">{t('prop.analysisMode')}</div>
+      <div className="prop-row">
+        <label>{t('prop.analysisMode')}</label>
+        <select
+          value={mode}
+          onChange={(e) => {
+            const result = setAnalysisMode(e.target.value as AnalysisMode);
+            setError(result.ok ? null : result.error);
+          }}
+        >
+          <option value="3d">{t('prop.analysisMode3d')}</option>
+          <option value="xz2d">{t('prop.analysisModeXz2d')}</option>
+        </select>
+      </div>
+      {error && <div className="error-text">{error}</div>}
     </div>
   );
 };

--- a/src/ui/panels/PropertyPanel.tsx
+++ b/src/ui/panels/PropertyPanel.tsx
@@ -4,7 +4,11 @@ import { useSelectionStore } from '../../state/selectionStore';
 import { useViewStore } from '../../state/viewStore';
 import { useT } from '../../i18n';
 import type { StructuralNode, Member, NodalLoad, MemberLoad, AnalysisMode } from '../../core/model/types';
-import { getAnalysisMode, XZ_2D_MODE } from '../../core/model/analysisMode';
+import {
+  findNodesOffXzPlane,
+  getAnalysisMode,
+  XZ_2D_MODE,
+} from '../../core/model/analysisMode';
 
 /** Distributive Omit that works correctly with union types */
 type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
@@ -47,6 +51,7 @@ export const PropertyPanel: React.FC = () => {
   return (
     <div className="property-panel">
       <h3>{t('prop.title')}</h3>
+      <AnalysisModeEditor />
 
       {selectedNodes.length === 1 && (
         <NodeProperties
@@ -64,12 +69,18 @@ export const PropertyPanel: React.FC = () => {
       {selectedMembers.length === 1 && (
         <MemberProperties
           member={selectedMembers[0]!}
+          analysisMode={analysisMode}
           model={model}
           memberLoads={model.memberLoads.filter((l) => l.memberId === selectedMembers[0]!.id)}
           onUpdate={updateMember}
           onDelete={removeMember}
           onAddLoad={(memberId) =>
-            addMemberLoad({ memberId, type: 'udl', direction: 'localY', value: -5 })
+            addMemberLoad({
+              memberId,
+              type: 'udl',
+              direction: analysisMode === XZ_2D_MODE ? 'localZ' : 'localY',
+              value: -5,
+            })
           }
           onUpdateLoad={updateMemberLoad}
           onRemoveLoad={removeMemberLoad}
@@ -78,7 +89,6 @@ export const PropertyPanel: React.FC = () => {
 
       {selectedNodes.length === 0 && selectedMembers.length === 0 && (
         <>
-          <AnalysisModeEditor />
           <MaterialsEditor />
           <SectionsEditor />
           <CouplingsEditor />
@@ -186,12 +196,18 @@ const AnalysisModeEditor: React.FC = () => {
   const t = useT();
   const mode = getAnalysisMode(model);
 
+  React.useEffect(() => {
+    if (error && findNodesOffXzPlane(model).length === 0) {
+      setError(null);
+    }
+  }, [error, model]);
+
   return (
     <div className="prop-group">
       <div className="prop-title">{t('prop.analysisMode')}</div>
       <div className="prop-row">
-        <label>{t('prop.analysisMode')}</label>
         <select
+          aria-label={t('prop.analysisMode')}
           value={mode}
           onChange={(e) => {
             const result = setAnalysisMode(e.target.value as AnalysisMode);
@@ -209,6 +225,7 @@ const AnalysisModeEditor: React.FC = () => {
 
 const MemberProperties: React.FC<{
   member: Member;
+  analysisMode: AnalysisMode;
   model: import('../../core/model/types').ProjectModel;
   memberLoads: MemberLoad[];
   onUpdate: (id: string, u: Partial<Pick<Member, 'sectionId' | 'codeAngle'>>) => void;
@@ -216,7 +233,7 @@ const MemberProperties: React.FC<{
   onAddLoad: (memberId: string) => void;
   onUpdateLoad: (id: string, updates: Partial<DistributiveOmit<MemberLoad, 'id'>>) => void;
   onRemoveLoad: (id: string) => void;
-}> = ({ member, model, memberLoads, onUpdate, onDelete, onAddLoad, onUpdateLoad, onRemoveLoad }) => {
+}> = ({ member, analysisMode, model, memberLoads, onUpdate, onDelete, onAddLoad, onUpdateLoad, onRemoveLoad }) => {
   const t = useT();
   const ni = model.nodes.find((n) => n.id === member.ni);
   const nj = model.nodes.find((n) => n.id === member.nj);
@@ -282,7 +299,7 @@ const MemberProperties: React.FC<{
                   <label>{t('prop.loadDirection')}</label>
                   <select value={load.direction}
                     onChange={(e) => onUpdateLoad(load.id, { direction: e.target.value as 'localX' | 'localY' | 'localZ' })}>
-                    <option value="localY">localY</option>
+                    <option value="localY" disabled={analysisMode === XZ_2D_MODE}>localY</option>
                     <option value="localZ">localZ</option>
                     <option value="localX">localX</option>
                   </select>

--- a/src/ui/tables/reactionRows.ts
+++ b/src/ui/tables/reactionRows.ts
@@ -1,4 +1,5 @@
 import type { ProjectModel } from '../../core/model/types';
+import { getAnalysisMode, getEffectiveRestraint } from '../../core/model/analysisMode';
 
 export type ReactionCell = {
   value: number | null;
@@ -18,6 +19,7 @@ export function buildEffectiveReactionRows(
   const nodeIdToIndex = new Map(model.nodes.map((n, i) => [n.id, i]));
   const nodeCount = model.nodes.length;
   const dofCount = nodeCount * 6;
+  const analysisMode = getAnalysisMode(model);
 
   // Build DOF map (same logic as indexing.ts)
   const dofMap = new Int32Array(dofCount);
@@ -38,7 +40,7 @@ export function buildEffectiveReactionRows(
 
   const constrainedSourceDofs = new Uint8Array(dofCount);
   for (let i = 0; i < model.nodes.length; i++) {
-    const r = model.nodes[i]!.restraint;
+    const r = getEffectiveRestraint(model.nodes[i]!.restraint, analysisMode);
     const flags = [r.ux, r.uy, r.uz, r.rx, r.ry, r.rz];
     for (let d = 0; d < 6; d++) {
       if (flags[d]) constrainedSourceDofs[i * 6 + d] = 1;


### PR DESCRIPTION
## Summary

Adds a 2D frame analysis mode for the X-Z plane. When this mode is selected, the solver treats out-of-plane node DOFs as restrained by automatically fixing `uy`, `rx`, and `rz` in the analysis-ready model while preserving the user's original 3D restraints.

## Details

- Adds `analysisMode` to project models, defaulting existing and imported models to `3d`.
- Blocks switching to 2D X-Z mode when any node has a nonzero Y coordinate.
- Keeps node Y coordinates at zero while 2D X-Z mode is active.
- Applies effective auto-restraints during indexing, validation, and reaction table rendering.
- Validates X-Z mode member orientation by requiring code angles on the 0/180-degree axis so local Y remains out-of-plane.
- Rejects out-of-plane nodal and member load components in X-Z mode instead of letting them turn into artificial reactions.
- Adds a property-panel selector that is always visible, disables the Y coordinate input for selected nodes, and defaults new member loads to `localZ` in X-Z mode.
- Documents that FrameJson imports are treated as 3D while native ProjectFile JSON preserves `analysisMode`.
- Adds tests for mode switching, Y-plane validation, automatic out-of-plane DOF restraints, invalid code angles, invalid out-of-plane loads, reaction rows, and toggling back to 3D.

## Validation

- `npm test`
- `npm run build`
- `npm run lint`